### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# This file is for unifying the coding style for different editors and IDEs.
+# More information at http://EditorConfig.org
+root = true
+
+# Baseline configuration (applies to all filetypes)
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+
+# Markdown customizations
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,17 @@
-# This file is for unifying the coding style for different editors and IDEs.
-# More information at http://EditorConfig.org
+# This file is used by editors and IDEs to unify coding standards
+# @see http://EditorConfig.org
+# @styling https://github.com/styleguide/ruby
+
 root = true
 
-# Baseline configuration (applies to all filetypes)
+# Default configuration (applies to all file types)
 [*]
 indent_style = space
 indent_size = 2
-end_of_line = lf
-charset = utf-8
 trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
 
 # Markdown customizations
 [*.md]


### PR DESCRIPTION
@barryclark awesome you committed #39

However, regarding "passing on [editorconfig](http://editorconfig.org)," I'd urge you to reconsider.  

It's a newer standard, but virtually all active and recent projects are using it, [here's a list](https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig).  I'd consider it "best practice" and a signature of an active project.  It allows contributors to easily conform to the standards of the project -- and shouldn't require any interaction by the end user.

I've modified the original patch from @LeoColomb  to create this pull request.  I also reviewed the editorconfig from octopress -- and found it a bit too specific/redundant.  We might want to review the editorconfig for jekyll-now, but I think this is a good starting point.

This file is based on documented and simplified versions of [Jekyll-now patch](https://github.com/barryclark/jekyll-now/commit/6bdf909a90cf94f93a4ca2b82f2319fa6fdc29a6) from @LeoColomb and a simplified [Octopress editorconfig](https://github.com/imathis/octopress/commit/05f54ab16b167656fb58b1f6503296dd44518132?diff=unified)
